### PR TITLE
Fix error handling in verification

### DIFF
--- a/lab7-8/gui.py
+++ b/lab7-8/gui.py
@@ -193,7 +193,7 @@ class DigitalSignatureApp(QWidget):
         hash_algo = self.combo_hash.currentText()
         try:
             hash_int = sha.compute_hash(msg, hash_algo)
-        except Exception:
+        except Exception as e:
             QMessageBox.critical(self, "Error", "Hashing failed: " + str(e))
             return
         algo = self.combo_sig.currentText()


### PR DESCRIPTION
## Summary
- fix bug where exception variable wasn't available during verification

## Testing
- `python - <<'PY'
import compileall
ok=compileall.compile_dir('lab7-8', quiet=1)
print('compile all', ok)
PY`

------
https://chatgpt.com/codex/tasks/task_e_683fec0412b88321a52b9a658608803a